### PR TITLE
items是POST中body,无需应用aliEncode

### DIFF
--- a/data_manage.go
+++ b/data_manage.go
@@ -12,6 +12,7 @@ func (o *OpenSearchClient) AddDoc(tableName, itemsJson string) AliResult {
 	sign, queryString := o.getAliSign(params, "POST")
 	url := fmt.Sprintf("%s/index/doc/%s?%s&Signature=%s", o.cf.OS_HOST, o.cf.OS_APPNAME, queryString, sign)
 	//fmt.Println(url)
-	itemsData := fmt.Sprintf("items=%s", aliEncode(itemsJson))
+	//itemsData := fmt.Sprintf("items=%s", aliEncode(itemsJson))
+	itemsData := "items="+itemsJson
 	return doHttpRequest(url, "POST", itemsData)
 }


### PR DESCRIPTION
阿里云的官方文档确实有是这样说的: xxxx, 把编码后的字符串中加号（+）替换成%20、星号（*）替换成%2A、%7E替换回波浪号（~），即可得到上述规则描述的编码字符串。

但是!!!，这个是用在URL的签名的，而 items 是用在 POST 的body内的，所以无需应用这一规则，经过我的实际测试，不用aliEncode也确实是OK的。
